### PR TITLE
php7: fix memory leak in dio_read.

### DIFF
--- a/php7/dio.c
+++ b/php7/dio.c
@@ -214,6 +214,7 @@ PHP_FUNCTION(dio_read)
 	data[res] = 0;
 
 	RETURN_STRINGL(data, res);
+	efree(data);
 }
 /* }}} */
 


### PR DESCRIPTION
In PHP 5, RETURN_STRINGL was called with 3rd argument set to 0 (aka do
not make copy). PHP 7 no longer takes this argument but requires to
free the allocated memory if it used to be 0 [1] else it will leak
memory.

[1] https://wiki.php.net/phpng-upgrading#strings