### PR TITLE
Add support for PHP 8 on Windows

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -3,15 +3,12 @@
 ARG_ENABLE("dio", "Enable the direct I/O support", "no");
 
 if (PHP_DIO != "no") {
-	var dll = get_define('PHPDLL');
 	var old_conf_dir = configure_module_dirname;
 
-	if (null != dll.match(/^php5/)) {
+	if (PHP_VERSION <= 5) {
 		configure_module_dirname = configure_module_dirname + "\\php5";
-	} else if (null != dll.match(/^php7/)) {
-		configure_module_dirname = configure_module_dirname + "\\php7";
 	} else {
-		ERROR("Cannot match any known PHP version with '" + dll + "'");
+		configure_module_dirname = configure_module_dirname + "\\php7";
 	}
 
 	EXTENSION("dio", "dio.c dio_common.c dio_win32.c dio_stream_wrappers.c");


### PR DESCRIPTION
We could extend the regex to let php8 DLLs use the php7/ folder, but
instead use the global variable `PHP_VERSION` to simplify the code
right away.  We use basically the same conditional logic as in
config.m4.