### PR TITLE
Remove link to obsolete bug tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-Issues: https://bugs.php.net/search.php?cmd=display&status=Open&package_name[]=dio
-


### PR DESCRIPTION
bugs.php.net is in the progress of being superseded, new non-security
bug reports cannot be filed, and there are no open issues regarding
dio.  Since GH issues are open for the extensions' repo, we can remove
this link.