### PR TITLE
Replace AC_TRY_COMPILE with AC_COMPILE_IFELSE and AC_LANG_PROGRAM

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -6,14 +6,14 @@ if test "$PHP_DIO" != "no"; then
 
   export OLD_CPPFLAGS="$CPPFLAGS"
   export CPPFLAGS="$CPPFLAGS $INCLUDES"
-  AC_TRY_COMPILE([#include <php_version.h>], [
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <php_version.h>]], [[
 #if PHP_MAJOR_VERSION > 5
 #error  PHP > 5
 #endif
-  ], [
+  ]])],[
     subdir=php5
     AC_MSG_RESULT([PHP 5.x])
-  ], [
+  ],[
     subdir=php7
     AC_MSG_RESULT([PHP 7.x])
   ])


### PR DESCRIPTION
The AC_TRY_COMPILE macro is obsolete:
http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.2